### PR TITLE
feat: Add ll-builder-utils linglong.yaml for archs

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+version: "1"
+package:
+  id: cn.org.linyaps.builder.utils
+  name: ll-builder-utils
+  version: 0.0.1.2
+  kind: app
+  description: |
+    Utils for ll-builder
+
+command: [/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export]
+
+base: org.deepin.base/25.2.1
+sources:
+  - kind: archive
+    url: https://github.com/erofs/erofs-utils/archive/refs/tags/v1.8.6.tar.gz
+    digest: 5b221dc3fd6d151425b30534ede46fb7a90dc233a8659cba0372796b0a066547
+    name: erofs-utils
+  - kind: archive
+    url: https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
+    digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+    name: fuse
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.1.0.tar.gz
+    digest: a5833d0ce4bafb33115cab422968c2ae8181aa100802cabe4b29665cd9e67b31
+    name: linyaps-box
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps/archive/refs/tags/1.9.10.tar.gz
+    digest: ef8ab31ec0804707c342bc4e9b3b3f7f3657c7cf0dbff9dd6b149164e617539c
+    name: linyaps
+build: |
+  echo "$PREFIX"
+
+  FUSE_TAG="3.17.1"
+  EROFS_UTILS_TAG="1.8.6"
+  LINYAPS_BOX_TAG="2.1.0"
+  LINYAPS_TAG="1.9.10"
+
+  # build libfuse static library
+  cd /project/linglong/sources/fuse/fuse-${FUSE_TAG}
+  patch lib/mount.c /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/apps/ll-builder-utils/patch/libfuse.patch
+  mkdir build || true
+  cd build
+  meson setup ../
+  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  ninja && ninja install
+
+  # build erofsfuse static library
+  cd /project/linglong/sources/erofs-utils/erofs-utils-${EROFS_UTILS_TAG}
+  ./autogen.sh
+  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  make -j$(nproc)
+  make install
+
+  # build static ll-box
+  cd /project/linglong/sources/linyaps-box/linyaps-box-${LINYAPS_BOX_TAG}/
+  cmake --preset static
+  cmake --build build-static -j$(nproc)
+  cmake --install build-static --prefix=$PREFIX
+
+  cd /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/
+  cmake -B build-linglong -DCPM_LOCAL_PACKAGES_ONLY=true -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
+  cmake --build build-linglong -j$(nproc)
+  cmake --install build-linglong --prefix=$PREFIX
+  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+buildext:
+  apt:
+    build_depends: [patch, meson, libtool, pkg-config, uuid-dev, libdeflate-dev, libzstd-dev, nlohmann-json3-dev, libyaml-cpp-dev, liblz4-dev, liblzma-dev, libselinux1-dev, libpcre2-dev, libelf-dev, libcap-dev, libcli11-dev, libgtest-dev]

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+version: "1"
+package:
+  id: cn.org.linyaps.builder.utils
+  name: ll-builder-utils
+  version: 0.0.1.2
+  kind: app
+  description: |
+    Utils for ll-builder
+
+command: [/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export]
+
+base: org.deepin.base/25.2.1
+sources:
+  - kind: archive
+    url: https://github.com/erofs/erofs-utils/archive/refs/tags/v1.8.6.tar.gz
+    digest: 5b221dc3fd6d151425b30534ede46fb7a90dc233a8659cba0372796b0a066547
+    name: erofs-utils
+  - kind: archive
+    url: https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
+    digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+    name: fuse
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.1.0.tar.gz
+    digest: a5833d0ce4bafb33115cab422968c2ae8181aa100802cabe4b29665cd9e67b31
+    name: linyaps-box
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps/archive/refs/tags/1.9.10.tar.gz
+    digest: ef8ab31ec0804707c342bc4e9b3b3f7f3657c7cf0dbff9dd6b149164e617539c
+    name: linyaps
+build: |
+  echo "$PREFIX"
+
+  FUSE_TAG="3.17.1"
+  EROFS_UTILS_TAG="1.8.6"
+  LINYAPS_BOX_TAG="2.1.0"
+  LINYAPS_TAG="1.9.10"
+
+  # build libfuse static library
+  cd /project/linglong/sources/fuse/fuse-${FUSE_TAG}
+  patch lib/mount.c /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/apps/ll-builder-utils/patch/libfuse.patch
+  mkdir build || true
+  cd build
+  meson setup ../
+  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  ninja && ninja install
+
+  # build erofsfuse static library
+  cd /project/linglong/sources/erofs-utils/erofs-utils-${EROFS_UTILS_TAG}
+  ./autogen.sh
+  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  make -j$(nproc)
+  make install
+
+  # build static ll-box
+  cd /project/linglong/sources/linyaps-box/linyaps-box-${LINYAPS_BOX_TAG}/
+  cmake --preset static
+  cmake --build build-static -j$(nproc)
+  cmake --install build-static --prefix=$PREFIX
+
+  cd /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/
+  cmake -B build-linglong -DCPM_LOCAL_PACKAGES_ONLY=true -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
+  cmake --build build-linglong -j$(nproc)
+  cmake --install build-linglong --prefix=$PREFIX
+  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+buildext:
+  apt:
+    build_depends: [patch, meson, libtool, pkg-config, uuid-dev, libdeflate-dev, libzstd-dev, nlohmann-json3-dev, libyaml-cpp-dev, liblz4-dev, liblzma-dev, libselinux1-dev, libpcre2-dev, libelf-dev, libcap-dev, libcli11-dev, libgtest-dev]

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+version: "1"
+package:
+  id: cn.org.linyaps.builder.utils
+  name: ll-builder-utils
+  version: 0.0.1.2
+  kind: app
+  description: |
+    Utils for ll-builder
+
+command: [/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export]
+
+base: org.deepin.base/25.2.1
+sources:
+  - kind: archive
+    url: https://github.com/erofs/erofs-utils/archive/refs/tags/v1.8.6.tar.gz
+    digest: 5b221dc3fd6d151425b30534ede46fb7a90dc233a8659cba0372796b0a066547
+    name: erofs-utils
+  - kind: archive
+    url: https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
+    digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+    name: fuse
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.1.0.tar.gz
+    digest: a5833d0ce4bafb33115cab422968c2ae8181aa100802cabe4b29665cd9e67b31
+    name: linyaps-box
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps/archive/refs/tags/1.9.10.tar.gz
+    digest: ef8ab31ec0804707c342bc4e9b3b3f7f3657c7cf0dbff9dd6b149164e617539c
+    name: linyaps
+build: |
+  echo "$PREFIX"
+
+  FUSE_TAG="3.17.1"
+  EROFS_UTILS_TAG="1.8.6"
+  LINYAPS_BOX_TAG="2.1.0"
+  LINYAPS_TAG="1.9.10"
+
+  # build libfuse static library
+  cd /project/linglong/sources/fuse/fuse-${FUSE_TAG}
+  patch lib/mount.c /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/apps/ll-builder-utils/patch/libfuse.patch
+  mkdir build || true
+  cd build
+  meson setup ../
+  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  ninja && ninja install
+
+  # build erofsfuse static library
+  cd /project/linglong/sources/erofs-utils/erofs-utils-${EROFS_UTILS_TAG}
+  ./autogen.sh
+  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  make -j$(nproc)
+  make install
+
+  # build static ll-box
+  cd /project/linglong/sources/linyaps-box/linyaps-box-${LINYAPS_BOX_TAG}/
+  cmake --preset static
+  cmake --build build-static -j$(nproc)
+  cmake --install build-static --prefix=$PREFIX
+
+  cd /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/
+  cmake -B build-linglong -DCPM_LOCAL_PACKAGES_ONLY=true -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
+  cmake --build build-linglong -j$(nproc)
+  cmake --install build-linglong --prefix=$PREFIX
+  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+buildext:
+  apt:
+    build_depends: [patch, meson, libtool, pkg-config, uuid-dev, libdeflate-dev, libzstd-dev, nlohmann-json3-dev, libyaml-cpp-dev, liblz4-dev, liblzma-dev, libselinux1-dev, libpcre2-dev, libelf-dev, libcap-dev, libcli11-dev, libgtest-dev]

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+version: "1"
+package:
+  id: cn.org.linyaps.builder.utils
+  name: ll-builder-utils
+  version: 0.0.1.2
+  kind: app
+  description: |
+    Utils for ll-builder
+
+command: [/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export]
+
+base: org.deepin.base/25.2.1
+sources:
+  - kind: archive
+    url: https://github.com/erofs/erofs-utils/archive/refs/tags/v1.8.6.tar.gz
+    digest: 5b221dc3fd6d151425b30534ede46fb7a90dc233a8659cba0372796b0a066547
+    name: erofs-utils
+  - kind: archive
+    url: https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
+    digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+    name: fuse
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.1.0.tar.gz
+    digest: a5833d0ce4bafb33115cab422968c2ae8181aa100802cabe4b29665cd9e67b31
+    name: linyaps-box
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps/archive/refs/tags/1.9.10.tar.gz
+    digest: ef8ab31ec0804707c342bc4e9b3b3f7f3657c7cf0dbff9dd6b149164e617539c
+    name: linyaps
+build: |
+  echo "$PREFIX"
+
+  FUSE_TAG="3.17.1"
+  EROFS_UTILS_TAG="1.8.6"
+  LINYAPS_BOX_TAG="2.1.0"
+  LINYAPS_TAG="1.9.10"
+
+  # build libfuse static library
+  cd /project/linglong/sources/fuse/fuse-${FUSE_TAG}
+  patch lib/mount.c /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/apps/ll-builder-utils/patch/libfuse.patch
+  mkdir build || true
+  cd build
+  meson setup ../
+  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  ninja && ninja install
+
+  # build erofsfuse static library
+  cd /project/linglong/sources/erofs-utils/erofs-utils-${EROFS_UTILS_TAG}
+  ./autogen.sh
+  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  make -j$(nproc)
+  make install
+
+  # build static ll-box
+  cd /project/linglong/sources/linyaps-box/linyaps-box-${LINYAPS_BOX_TAG}/
+  cmake --preset static
+  cmake --build build-static -j$(nproc)
+  cmake --install build-static --prefix=$PREFIX
+
+  cd /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/
+  cmake -B build-linglong -DCPM_LOCAL_PACKAGES_ONLY=true -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
+  cmake --build build-linglong -j$(nproc)
+  cmake --install build-linglong --prefix=$PREFIX
+  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+buildext:
+  apt:
+    build_depends: [patch, meson, libtool, pkg-config, uuid-dev, libdeflate-dev, libzstd-dev, nlohmann-json3-dev, libyaml-cpp-dev, liblz4-dev, liblzma-dev, libselinux1-dev, libpcre2-dev, libelf-dev, libcap-dev, libcli11-dev, libgtest-dev]

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+version: "1"
+package:
+  id: cn.org.linyaps.builder.utils
+  name: ll-builder-utils
+  version: 0.0.1.2
+  kind: app
+  description: |
+    Utils for ll-builder
+
+command: [/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export]
+
+base: org.deepin.base/25.2.1
+sources:
+  - kind: archive
+    url: https://github.com/erofs/erofs-utils/archive/refs/tags/v1.8.6.tar.gz
+    digest: 5b221dc3fd6d151425b30534ede46fb7a90dc233a8659cba0372796b0a066547
+    name: erofs-utils
+  - kind: archive
+    url: https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
+    digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+    name: fuse
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.1.0.tar.gz
+    digest: a5833d0ce4bafb33115cab422968c2ae8181aa100802cabe4b29665cd9e67b31
+    name: linyaps-box
+  - kind: archive
+    url: https://github.com/OpenAtom-Linyaps/linyaps/archive/refs/tags/1.9.10.tar.gz
+    digest: ef8ab31ec0804707c342bc4e9b3b3f7f3657c7cf0dbff9dd6b149164e617539c
+    name: linyaps
+build: |
+  echo "$PREFIX"
+
+  FUSE_TAG="3.17.1"
+  EROFS_UTILS_TAG="1.8.6"
+  LINYAPS_BOX_TAG="2.1.0"
+  LINYAPS_TAG="1.9.10"
+
+  # build libfuse static library
+  cd /project/linglong/sources/fuse/fuse-${FUSE_TAG}
+  patch lib/mount.c /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/apps/ll-builder-utils/patch/libfuse.patch
+  mkdir build || true
+  cd build
+  meson setup ../
+  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  ninja && ninja install
+
+  # build erofsfuse static library
+  cd /project/linglong/sources/erofs-utils/erofs-utils-${EROFS_UTILS_TAG}
+  ./autogen.sh
+  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  make -j$(nproc)
+  make install
+
+  # build static ll-box
+  cd /project/linglong/sources/linyaps-box/linyaps-box-${LINYAPS_BOX_TAG}/
+  cmake --preset static
+  cmake --build build-static -j$(nproc)
+  cmake --install build-static --prefix=$PREFIX
+
+  cd /project/linglong/sources/linyaps/linyaps-${LINYAPS_TAG}/
+  cmake -B build-linglong -DCPM_LOCAL_PACKAGES_ONLY=true -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
+  cmake --build build-linglong -j$(nproc)
+  cmake --install build-linglong --prefix=$PREFIX
+  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+buildext:
+  apt:
+    build_depends: [patch, meson, libtool, pkg-config, uuid-dev, libdeflate-dev, libzstd-dev, nlohmann-json3-dev, libyaml-cpp-dev, liblz4-dev, liblzma-dev, libselinux1-dev, libpcre2-dev, libelf-dev, libcap-dev, libcli11-dev, libgtest-dev]


### PR DESCRIPTION
1.  Added `linglong.yaml` files for `arm64`, `loong64`, `mips64`, and `sw64` architectures.
2.  These files define the build configurations for the `ll-builder- utils` package, including the package ID, name, version, description, command, base image, sources (erofs-utils, fuse, linyaps-box, linyaps), build steps, and build dependencies.
3.  The build steps involve building libfuse, erofsfuse, ll-box and ll- builder-utils as static libraries and installing them to the prefix directory.
4.  These files are required for building the ll-builder-utils package on these architectures using the linglong build system.

Influence:
1. Verify that the `ll-builder-utils` package builds successfully on `arm64`, `loong64`, `mips64`, and `sw64` architectures.
2.  Test the functionality of the `ll-builder-export` command after installation.
3.  Confirm that all dependencies are correctly resolved and installed.

feat: 为架构添加 ll-builder-utils linglong.yaml

1. 为 `arm64`、`loong64`、`mips64` 和 `sw64` 架构添加了 `linglong.yaml` 文件。
2. 这些文件定义了 `ll-builder-utils` 软件包的构建配置，包括软件包 ID、 名称、版本、描述、命令、基础镜像、源（erofs-utils、fuse、linyaps-box、
linyaps）、构建步骤和构建依赖项。
3. 构建步骤包括将 libfuse、erofsfuse、ll-box 和 ll-builder-utils 构建为 静态库，并将它们安装到前缀目录。
4. 这些文件是使用 linglong 构建系统在这些架构上构建 ll-builder-utils 软 件包所必需的。

Influence:
1. 验证 `ll-builder-utils` 软件包是否在 `arm64`、`loong64`、`mips64` 和 `sw64` 架构上成功构建。
2. 安装后测试 `ll-builder-export` 命令的功能。
3. 确认所有依赖项都已正确解析和安装。